### PR TITLE
Add Optional API Key Parameter for Authentication in `AiklyraClient`  

### DIFF
--- a/aiklyra/client.py
+++ b/aiklyra/client.py
@@ -38,18 +38,22 @@ class AiklyraClient:
     BASE_ANALYSE_ENDPOINT = "conversation-flow-analysis/analyse-conversation"
     JOB_STATUS_ENDPOINT = "conversation-flow-analysis/job-status"
 
-    def __init__(self, base_url: str = "http://localhost:8002"):
+    def __init__(self, base_url: str = "http://localhost:8002" , api_key : str = None):
         """
         Initialize the Aiklyra client.
 
         Args:
             base_url (str, optional): The base URL of the Aiklyra API. Defaults to "http://localhost:8002".
+        api_key (str, optional): The API key to use for authentication for dataset size > 100. Defaults to None.
         """
+        self.api_key = api_key 
         self.base_url = base_url.rstrip('/')
         self.headers = {
             "Content-Type": "application/json",
-            "accept": "application/json"
+            "accept": "application/json",
         }
+        if self.api_key :
+            self.headers["Authorization"] = f"Bearer {self.api_key}"
 
     def submit_analysis(
         self,


### PR DESCRIPTION
**Description:**  
This PR introduces an optional `api_key` parameter in the `AiklyraClient` class, allowing authentication for requests when needed. If an API key is provided, it is automatically added to the request headers as a **Bearer token**.  

**Changes:**  
- Added an `api_key` parameter to `AiklyraClient.__init__` with a default value of `None`.  
- Updated the client to include the API key in the request headers if provided.  
- Improved documentation for the `api_key` argument, clarifying its purpose (required for dataset sizes > 100).  

**Why this is needed:**  
- Enables authentication for API calls when necessary.  
- Ensures seamless access control without breaking existing functionality.  
- Maintains backward compatibility for users who do not require authentication.  

**Testing:**  
- Verified that requests work without an API key (default behavior remains unchanged).  
- Tested with a valid API key to confirm the `Authorization` header is set correctly.  
- Ensured that existing functionality remains unaffected.  
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/a3fd6172-bc5a-427b-9f1a-1b5862ac958b" />
**Future Improvements:**  
- Consider implementing automatic API key validation during initialization.  
- Extend support for API key authentication in other request methods if needed.  
